### PR TITLE
Stricter API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,13 +11,13 @@ Minimal usage example:
 
 .. code-block:: python
 
-    from wires import wire
+    from wires import wiring, wire
 
     def my_callable():
         print('Hello from wires!')
 
     wire.this_callable.calls_to(my_callable)
-    wire.this_callable()
+    wiring.this_callable()
 
 
 

--- a/src/wires/__init__.py
+++ b/src/wires/__init__.py
@@ -25,7 +25,7 @@ __author__ = 'Tiago Montes'
 __email__ = 'tiago.montes@gmail.com'
 
 
-from . _shell import WiresShell as Wires
+from . _shell import WiringShell as Wiring
 from . _singleton import wire, unwire
 
 

--- a/src/wires/__init__.py
+++ b/src/wires/__init__.py
@@ -26,7 +26,7 @@ __email__ = 'tiago.montes@gmail.com'
 
 
 from . _shell import WiringShell as Wiring
-from . _singleton import wire, unwire
+from . _singleton import wiring, wire, unwire
 
 
 # ----------------------------------------------------------------------------

--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -17,7 +17,7 @@ from traceback import print_exception
 
 
 
-class Callable(object):
+class WiringCallable(object):
 
     """
     Callable with a minimal API.

--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -35,10 +35,26 @@ class WiringCallable(object):
         self._logger_name = logger_name
 
         # See `_log_handler_failure` below.
-        self.use_log = True
+        self._use_log = True
 
         # Wired (callee, wire-time args, wire-time kwargs) tuples.
         self._functions = []
+
+
+    @property
+    def use_log(self):
+
+        if self._wiring._wire_context is not None:
+            raise RuntimeError('invalid access in wiring context')
+        return self._use_log
+
+
+    @use_log.setter
+    def use_log(self, value):
+
+        if self._wiring._wire_context is not None:
+            raise RuntimeError('invalid access in wiring context')
+        self._use_log = value
 
 
     def calls_to(self, function, *args, **kwargs):
@@ -53,19 +69,27 @@ class WiringCallable(object):
         if not callable(function):
             raise ValueError('argument not callable: %r' % (function,))
 
-        # Wire/unwire depending on our instance's `_wire_context` attribute.
-        if self._wiring._wire_context:
+        # Wire/unwire depending on our wiring `_wire_context` attribute.
+        wire_context = self._wiring._wire_context
+        self._wiring._wire_context = None
+
+        if wire_context is True:
             self._functions.append((function, args, kwargs))
-        else:
+        elif wire_context is False:
             tuples_to_remove = [v for v in self._functions if v[0] == function]
             if not tuples_to_remove:
                 raise ValueError('unknown function %r' % (function,))
             self._functions.remove(tuples_to_remove[0])
+        else:
+            raise RuntimeError('undefined wiring context')
 
 
     def __call__(self, *args, **kwargs):
 
         # Calls all callee functions.
+
+        if self._wiring._wire_context is not None:
+            raise RuntimeError('calling within wiring context')
 
         for function, wire_args, wire_kwargs in self._functions:
             try:

--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -28,10 +28,10 @@ class Callable(object):
       arguments given to call combined with the wire-time callee arguments.
     """
 
-    def __init__(self, name, wires, logger_name='wires'):
+    def __init__(self, name, wiring, logger_name='wires'):
 
         self._name = name
-        self._wires = wires
+        self._wiring = wiring
         self._logger_name = logger_name
 
         # See `_log_handler_failure` below.
@@ -54,7 +54,7 @@ class Callable(object):
             raise ValueError('argument not callable: %r' % (function,))
 
         # Wire/unwire depending on our instance's `_wire_context` attribute.
-        if self._wires._wire_context:
+        if self._wiring._wire_context:
             self._functions.append((function, args, kwargs))
         else:
             tuples_to_remove = [v for v in self._functions if v[0] == function]

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -44,7 +44,7 @@ class WiringInstance(object):
         try:
             return self._callables[name]
         except KeyError:
-            new_callable = _callable.Callable(name, self)
+            new_callable = _callable.WiringCallable(name, self)
             self._callables[name] = new_callable
             return new_callable
 

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Python Wires Instance.
+Python Wiring Instance.
 """
 
 from __future__ import absolute_import
@@ -15,10 +15,10 @@ from . import _callable
 
 
 
-class WiresInstance(object):
+class WiringInstance(object):
 
     """
-    Python Wires Instance
+    Python Wiring Instance
     """
 
     # Should be used wrapped in a Wires Shell.

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -32,8 +32,9 @@ class WiringInstance(object):
         self._callables = {}
 
         # Our callers' `calls_to` method checks this attribute to decide
-        # whether to wire or unwire the passed in callee.
-        self._wire_context = True
+        # whether to wire or unwire the passed in callee; also used to
+        # disallow calling from within wiring/unwiring contexts.
+        self._wire_context = None
 
 
     def __getattr__(self, name):

--- a/src/wires/_shell.py
+++ b/src/wires/_shell.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Python Wires Shell.
+Python Wiring Shell.
 """
 
 from __future__ import absolute_import
@@ -15,26 +15,26 @@ from . import _instance
 
 
 
-class WiresShell(object):
+class WiringShell(object):
 
     """
-    Python Wires Shell
+    Python Wiring Shell
     """
 
-    # Wraps a Wires Instance, cooperating with it by setting its
+    # Wraps a Wiring Instance, cooperating with it by setting its
     # `wire_context` attribute to support the defined usage as in:
     #
-    # >>> ws = WiresShell()
+    # >>> ws = WiringShell()
     # >>> ws.wire.some_callable.calls_to(<callee>)
     # >>> ws.unwire.some_callable.calls_to(<callee>)
     #
-    # The `calls_to` method of the Wires Callable wires/unwires the given
-    # `<callee>` depending on its Wires Instance `wire_context`, set by
-    # the WiresShell object.
+    # The `calls_to` method of the Wiring Callable wires/unwires the given
+    # `<callee>` depending on its Wiring Instance `wire_context`, set by
+    # the WiringShell object.
 
     def __init__(self):
 
-        self._wires_instance = _instance.WiresInstance()
+        self._wiring = _instance.WiringInstance()
 
 
     @property
@@ -42,8 +42,8 @@ class WiresShell(object):
         """
         Callable/callee wiring attribute.
         """
-        self._wires_instance._wire_context = True
-        return self._wires_instance
+        self._wiring._wire_context = True
+        return self._wiring
 
 
     @property
@@ -51,13 +51,13 @@ class WiresShell(object):
         """
         Callable/callee unwiring attribute.
         """
-        self._wires_instance._wire_context = False
-        return self._wires_instance
+        self._wiring._wire_context = False
+        return self._wiring
 
 
     def __getattr__(self, name):
 
-        return getattr(self._wires_instance, name)
+        return getattr(self._wiring, name)
 
 
 # ----------------------------------------------------------------------------

--- a/src/wires/_singleton.py
+++ b/src/wires/_singleton.py
@@ -17,8 +17,8 @@ from . import _shell
 
 class _Wrapper(object):
 
-    def __init__(self, wires_shell):
-        self._wires_shell = wires_shell
+    def __init__(self, wiring_shell):
+        self._wiring_shell = wiring_shell
 
     def __getitem__(self, name):
         return getattr(self, name)
@@ -28,25 +28,25 @@ class _Wrapper(object):
 class _WireWrapper(_Wrapper):
 
     def __getattr__(self, name):
-        self._wires_shell._wires_instance._wire_context = True
-        return getattr(self._wires_shell._wires_instance, name)
+        self._wiring_shell._wiring._wire_context = True
+        return getattr(self._wiring_shell._wiring, name)
 
 
 
 class _UnwireWrapper(_Wrapper):
 
     def __getattr__(self, name):
-        self._wires_shell._wires_instance._wire_context = False
-        return getattr(self._wires_shell._wires_instance, name)
+        self._wiring_shell._wiring._wire_context = False
+        return getattr(self._wiring_shell._wiring, name)
 
 
 
 class _WiresSingleton(object):
 
     def __init__(self):
-        wires_shell = _shell.WiresShell()
-        self.wire = _WireWrapper(wires_shell)
-        self.unwire = _UnwireWrapper(wires_shell)
+        wiring_shell = _shell.WiringShell()
+        self.wire = _WireWrapper(wiring_shell)
+        self.unwire = _UnwireWrapper(wiring_shell)
 
 
 

--- a/src/wires/_singleton.py
+++ b/src/wires/_singleton.py
@@ -44,14 +44,15 @@ class _UnwireWrapper(_Wrapper):
 class _WiresSingleton(object):
 
     def __init__(self):
-        wiring_shell = _shell.WiringShell()
-        self.wire = _WireWrapper(wiring_shell)
-        self.unwire = _UnwireWrapper(wiring_shell)
+        self.wiring_shell = _shell.WiringShell()
+        self.wire = _WireWrapper(self.wiring_shell)
+        self.unwire = _UnwireWrapper(self.wiring_shell)
 
 
 
 _WIRE_SINGLETON = _WiresSingleton()
 
+wiring = _WIRE_SINGLETON.wiring_shell
 wire = _WIRE_SINGLETON.wire
 unwire = _WIRE_SINGLETON.unwire
 

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -35,7 +35,7 @@ class TestWiresAPI(unittest.TestCase):
         """
         Calling an unwired call works. Does nothing, but works.
         """
-        self.w.wire.unwired_call()
+        self.w.unwired_call()
 
 
     def test_wiring_non_callable_raises_value_error(self):
@@ -123,6 +123,60 @@ class TestWiresAPI(unittest.TestCase):
         name = 'name'
         self.w.wire[name].calls_to(self._test_callable)
         self.w.unwire[name].calls_to(self._test_callable)
+
+
+    def test_call_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            self.w.wire.some_callable()
+
+        # TODO: assert exception details
+
+
+    def test_call_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            self.w.unwire.some_callable()
+
+        # TODO: assert exception details
+
+
+    def test_callable_get_use_log_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            _ = self.w.wire.some_callable.use_log
+
+        # TODO: assert exception details
+
+
+    def test_callable_get_use_log_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            _ = self.w.unwire.some_callable.use_log
+
+        # TODO: assert exception details
+
+
+    def test_callable_set_use_log_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            self.w.wire.some_callable.use_log = None
+
+        # TODO: assert exception details
+
+
+    def test_callable_set_use_log_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            self.w.unwire.some_callable.use_log = None
+
+        # TODO: assert exception details
 
 
 
@@ -425,7 +479,7 @@ class ArgPassingMixin(helpers.CallTrackerAssertMixin):
 
         self.w = Wiring()
         self.w.wire.this.calls_to(tracker, *self.wire1_args, **self.wire1_kwargs)
-        self.w.this.calls_to(tracker, *self.wire2_args, **self.wire2_kwargs)
+        self.w.wire.this.calls_to(tracker, *self.wire2_args, **self.wire2_kwargs)
         self.w.this(*self.call_args, **self.call_kwargs)
         self.addCleanup(self._unwire, tracker)
         self.addCleanup(self._unwire, tracker)

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -14,7 +14,7 @@ import sys
 
 import six
 
-from wires import wire, unwire
+from wires import wiring, wire, unwire
 
 from . import helpers
 
@@ -31,7 +31,7 @@ class TestWiresAPI(unittest.TestCase):
         """
         Calling an unwired call works. Does nothing, but works.
         """
-        wire.unwired_call()
+        wiring.unwired_call()
 
 
     def test_wiring_non_callable_raises_value_error(self):
@@ -136,7 +136,7 @@ class TestWiresUtilization(helpers.CallTrackerAssertMixin, unittest.TestCase):
         tracker = helpers.CallTracker()
 
         wire.this.calls_to(tracker)
-        wire.this()
+        wiring.this()
 
         self.assertEqual(tracker.call_count, 1, 'call count mismatch')
         self.assertEqual(tracker.call_args, [
@@ -153,7 +153,7 @@ class TestWiresUtilization(helpers.CallTrackerAssertMixin, unittest.TestCase):
 
         wire.this.calls_to(tracker)
         wire.this.calls_to(tracker)
-        wire.this()
+        wiring.this()
 
         self.assertEqual(tracker.call_count, 2, 'call count mismatch')
         self.assertEqual(tracker.call_args, [
@@ -175,7 +175,7 @@ class TestWiresUtilization(helpers.CallTrackerAssertMixin, unittest.TestCase):
         for tracker in trackers:
             wire.this.calls_to(tracker)
 
-        wire.this()
+        wiring.this()
 
         for tracker in trackers:
             self.assertEqual(tracker.call_count, 1, 'call count mismatch')
@@ -194,12 +194,12 @@ class TestWiresUtilization(helpers.CallTrackerAssertMixin, unittest.TestCase):
         tracker = helpers.CallTracker()
 
         wire.this.calls_to(tracker)
-        wire.this()
+        wiring.this()
 
         self.assert_single_call_no_args(tracker)
 
         unwire.this.calls_to(tracker)
-        wire.this()
+        wiring.this()
 
         self.assert_single_call_no_args(tracker)
 
@@ -245,7 +245,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         No output to sys.stderr should be produced.
         """
         wire.will_fail.use_log = True
-        wire.will_fail()
+        wiring.will_fail()
 
         # We get two log records:
         # - The first one with a "custom" call fail record.
@@ -327,7 +327,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         Failure is output to sys.stderr.
         """
         wire.will_fail.use_log = False
-        wire.will_fail()
+        wiring.will_fail()
 
         # We get no log records.
         self.assertEqual(len(self.log_handler.records), 0, 'logged record count')
@@ -368,7 +368,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         No output to sys.stderr.
         """
         wire.will_fail.use_log = None
-        wire.will_fail()
+        wiring.will_fail()
 
         # We get no log records.
         self.assertEqual(len(self.log_handler.records), 0, 'log record count')
@@ -402,7 +402,7 @@ class ArgPassingMixin(helpers.CallTrackerAssertMixin):
         tracker = helpers.CallTracker()
 
         wire.this.calls_to(tracker, *self.wire1_args, **self.wire1_kwargs)
-        wire.this(*self.call_args, **self.call_kwargs)
+        wiring.this(*self.call_args, **self.call_kwargs)
         self.addCleanup(self._unwire, tracker)
 
         self.assertEqual(tracker.call_count, 1, 'call count mismatch')
@@ -420,7 +420,7 @@ class ArgPassingMixin(helpers.CallTrackerAssertMixin):
 
         wire.this.calls_to(tracker, *self.wire1_args, **self.wire1_kwargs)
         wire.this.calls_to(tracker, *self.wire2_args, **self.wire2_kwargs)
-        wire.this(*self.call_args, **self.call_kwargs)
+        wiring.this(*self.call_args, **self.call_kwargs)
         self.addCleanup(self._unwire, tracker)
         self.addCleanup(self._unwire, tracker)
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -121,6 +121,60 @@ class TestWiresAPI(unittest.TestCase):
         unwire[name].calls_to(self._test_callable)
 
 
+    def test_call_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            wire.some_callable()
+
+        # TODO: assert exception details
+
+
+    def test_call_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            unwire.some_callable()
+
+        # TODO: assert exception details
+
+
+    def test_call_get_use_log_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            _ = wire.some_callable.use_log
+
+        # TODO: assert exception details
+
+
+    def test_call_get_use_log_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            _ = unwire.some_callable.use_log
+
+        # TODO: assert exception details
+
+
+    def test_call_set_use_log_via_wire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            wire.some_callable.use_log = None
+
+        # TODO: assert exception details
+
+
+    def test_call_set_use_log_via_unwire_fails(self):
+        """
+        """
+        with self.assertRaises(RuntimeError) as cm:
+            unwire.some_callable.use_log = None
+
+        # TODO: assert exception details
+
+
 
 class TestWiresUtilization(helpers.CallTrackerAssertMixin, unittest.TestCase):
 
@@ -244,7 +298,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         Callee exceptions are logged by default.
         No output to sys.stderr should be produced.
         """
-        wire.will_fail.use_log = True
+        wiring.will_fail.use_log = True
         wiring.will_fail()
 
         # We get two log records:
@@ -326,7 +380,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         No records logged at all.
         Failure is output to sys.stderr.
         """
-        wire.will_fail.use_log = False
+        wiring.will_fail.use_log = False
         wiring.will_fail()
 
         # We get no log records.
@@ -367,7 +421,7 @@ class TestWiresCalleeFailures(unittest.TestCase):
         No records logged at all.
         No output to sys.stderr.
         """
-        wire.will_fail.use_log = None
+        wiring.will_fail.use_log = None
         wiring.will_fail()
 
         # We get no log records.


### PR DESCRIPTION
* Wiring instance must be used to trigger calls and access the callables `use_log` attribute.
* Wiring instance callable `.calls_to()` can only be used in the proper wire/unwire context
* Global singleton API changed now includes `wiring` the global wiring singleton, while keeping the `wire`/`unwire` shortcuts; same rules apply: can't trigger calls or access the `use_log` attribute from the `wire`/`unwire` shortcuts.