### PR TITLE
Redesigned the wiring/unwiring context tracking code.

### DIFF
--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -15,6 +15,11 @@ from __future__ import absolute_import
 
 class _ActionContext(object):
 
+    """
+    Supports `WiringShell.wire.<callable>` and `WiringShell.unwire.<callable>`
+    wiring action contexts.
+    """
+
     def __init__(self, wiring_callable):
 
         self._wiring_callable = wiring_callable
@@ -27,16 +32,28 @@ class _ActionContext(object):
 
 class WiringActionContext(_ActionContext):
 
-    def calls_to(self, function, *args, **kwargs):
+    """
+    The `WiringShell.wire.<callable>` context.
+    """
 
+    def calls_to(self, function, *args, **kwargs):
+        """
+        Wiring action `WiringShell.wire.<callable>.calls_to(...)`.
+        """
         return self._wiring_callable.wire(function, *args, **kwargs)
 
 
 
 class UnwiringActionContext(_ActionContext):
 
-    def calls_to(self, function):
+    """
+    The `WiringShell.unwire.<callable>` context.
+    """
 
+    def calls_to(self, function):
+        """
+        Unwiring action `WiringShell.unwire.<callable>.calls_to(...)`.
+        """
         return self._wiring_callable.unwire(function)
 
 
@@ -92,7 +109,13 @@ class WiringCallable(object):
         self._callees.remove(tuples_to_remove[0])
 
 
-    def calls_to(self, *_args, **_kwargs):
+    @staticmethod
+    def calls_to(*_args, **_kwargs):
+
+        """
+        Called outside of a wiring action context, which makes no sense, as in
+        `WiringShell.<callable>.calls_to(...)`.
+        """
 
         raise RuntimeError('undefined wiring context')
 

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -17,6 +17,11 @@ from . import _callable
 
 class _InstanceActionContext(object):
 
+    """
+    Supports `WiringShell.wire.<callable>` and `WiringShell.unwire.<callable>`
+    wiring action contexts.
+    """
+
     def __init__(self, wiring_instance):
 
         self._wiring_instance = wiring_instance
@@ -36,11 +41,19 @@ class _InstanceActionContext(object):
 
 class InstanceWiringActionContext(_InstanceActionContext):
 
+    """
+    The `WiringShell.wire.<callable>` context.
+    """
+
     callable_action_context = _callable.WiringActionContext
 
 
 
 class InstanceUnwiringActionContext(_InstanceActionContext):
+
+    """
+    The `WiringShell.unwire.<callable>` context.
+    """
 
     callable_action_context = _callable.UnwiringActionContext
 

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -15,6 +15,37 @@ from . import _callable
 
 
 
+class _InstanceActionContext(object):
+
+    def __init__(self, wiring_instance):
+
+        self._wiring_instance = wiring_instance
+
+
+    def __getitem__(self, name):
+
+        return getattr(self, name)
+
+
+    def __getattr__(self, name):
+
+        wiring_callable = getattr(self._wiring_instance, name)
+        return self.callable_action_context(wiring_callable)
+
+
+
+class InstanceWiringActionContext(_InstanceActionContext):
+
+    callable_action_context = _callable.WiringActionContext
+
+
+
+class InstanceUnwiringActionContext(_InstanceActionContext):
+
+    callable_action_context = _callable.UnwiringActionContext
+
+
+
 class WiringInstance(object):
 
     """
@@ -33,11 +64,6 @@ class WiringInstance(object):
         # - Values are Callable objects.
 
         self._callables = {}
-
-        # Our callers' `calls_to` method checks this attribute to decide
-        # whether to wire or unwire the passed in callee; also used to
-        # disallow calling from within wiring/unwiring contexts.
-        self._wire_context = None
 
         # Call coupling behavior is set by the shell, which will be dynamically
         # overridden via its `coupled_call` and `decoupled_call` attributes,
@@ -65,13 +91,6 @@ class WiringInstance(object):
             new_callable = _callable.WiringCallable(name, self)
             self._callables[name] = new_callable
             return new_callable
-
-
-    def __getitem__(self, name):
-
-        # Support attribute access for simpler dynamic name wiring/unwiring.
-
-        return self.__getattr__(name)
 
 
 # ----------------------------------------------------------------------------

--- a/src/wires/_shell.py
+++ b/src/wires/_shell.py
@@ -55,8 +55,7 @@ class WiringShell(object):
         """
         Callable/callee wiring attribute.
         """
-        self._wiring._wire_context = True
-        return self._wiring
+        return _instance.InstanceWiringActionContext(self._wiring)
 
 
     @property
@@ -64,8 +63,7 @@ class WiringShell(object):
         """
         Callable/callee unwiring attribute.
         """
-        self._wiring._wire_context = False
-        return self._wiring
+        return _instance.InstanceUnwiringActionContext(self._wiring)
 
 
     @property

--- a/src/wires/_singleton.py
+++ b/src/wires/_singleton.py
@@ -15,46 +15,11 @@ from . import _shell
 
 
 
-class _Wrapper(object):
+_WIRING_SINGLETON = _shell.WiringShell()
 
-    def __init__(self, wiring_shell):
-        self._wiring_shell = wiring_shell
-
-    def __getitem__(self, name):
-        return getattr(self, name)
-
-
-
-class _WireWrapper(_Wrapper):
-
-    def __getattr__(self, name):
-        self._wiring_shell._wiring._wire_context = True
-        return getattr(self._wiring_shell._wiring, name)
-
-
-
-class _UnwireWrapper(_Wrapper):
-
-    def __getattr__(self, name):
-        self._wiring_shell._wiring._wire_context = False
-        return getattr(self._wiring_shell._wiring, name)
-
-
-
-class _WiresSingleton(object):
-
-    def __init__(self):
-        self.wiring_shell = _shell.WiringShell()
-        self.wire = _WireWrapper(self.wiring_shell)
-        self.unwire = _UnwireWrapper(self.wiring_shell)
-
-
-
-_WIRE_SINGLETON = _WiresSingleton()
-
-wiring = _WIRE_SINGLETON.wiring_shell
-wire = _WIRE_SINGLETON.wire
-unwire = _WIRE_SINGLETON.unwire
+wiring = _WIRING_SINGLETON
+wire = _WIRING_SINGLETON.wire
+unwire = _WIRING_SINGLETON.unwire
 
 
 # ----------------------------------------------------------------------------

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -57,6 +57,33 @@ class TestWiresAPIMixin(object):
             )
 
 
+    def test_unwiring_non_callable_raises_value_error(self):
+        """
+        Unwiring a call from a non-callable raises ValueError.
+        The exception argument (message):
+        - Starts with "argument not callable: ".
+        - Contains repr(argument).
+        """
+        for non_callable in (None, True, 42, 2.3, (), [], {}, set()):
+
+            with self.assertRaises(ValueError) as cm:
+                self.unwire.this.calls_to(non_callable)
+
+            exception_args = cm.exception.args
+            self.assertEqual(len(exception_args), 1)
+
+            msg = exception_args[0]
+            self.assertTrue(
+                msg.startswith('argument not callable: '),
+                'wrong exception message: %r' % (msg,),
+            )
+            self.assertIn(
+                repr(non_callable),
+                msg,
+                'missing argument repr in message: %r' % (msg,),
+            )
+
+
     def test_wiring_callable_works(self):
         """
         Wiring a callable works.


### PR DESCRIPTION
Now much cleaner at the cost of a few additional classes and runtime allocation/deallocations per wiring/unwiring action.

Given that correctness, readability and maintainability precede performance, this will go in. If we ever need faster and lighter wiring/unwiring actions we'll get to that: then, not now.