### PR TITLE
Attribute renaming for more consistency + Less args for WiringCallable.

### DIFF
--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Python Wires Callable.
+Python Wiring Callable.
 """
 
 from __future__ import absolute_import
@@ -69,11 +69,9 @@ class WiringCallable(object):
       arguments given to call combined with the wire-time callee arguments.
     """
 
-    def __init__(self, name, wiring, logger_name='wires'):
+    def __init__(self, wiring_instance):
 
-        self._name = name
-        self._wiring = wiring
-        self._logger_name = logger_name
+        self._wiring_instance = wiring_instance
 
         # Wired (callee, wire-time args, wire-time kwargs) tuples.
         self._callees = []
@@ -125,8 +123,8 @@ class WiringCallable(object):
         # Get call coupling behaviour for this call from our WiringInstance and
         # then reset it to its default value to account for correct "default"
         # vs "overridden" call coupling behaviour.
-        call_coupling = self._wiring.coupling
-        self._wiring.coupling_reset()
+        call_coupling = self._wiring_instance.coupling
+        self._wiring_instance.coupling_reset()
 
         # Will contain (<exception>, <result>) per-callee tuples.
         call_result = []

--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -67,30 +67,29 @@ class WiringInstance(object):
 
     # Should be used wrapped in a Wires Shell.
 
-    def __init__(self, shell):
+    def __init__(self, wiring_shell):
 
         # Needed to track parameters like `coupling`.
-        self._shell = shell
+        self._wiring_shell = wiring_shell
 
         # Tracks known Callable instances:
-        # - Keys are callable names (my dynamic attributes).
-        # - Values are Callable objects.
-
-        self._callables = {}
+        # - Keys are callable names (this instance's dynamic attributes).
+        # - Values are WiringCallable objects.
+        self._wiring_callables = {}
 
         # Call coupling behavior is set by the shell, which will be dynamically
         # overridden via its `coupled_call` and `decoupled_call` attributes,
         # that set our `coupled` attribute. Callables check this attribute to
         # determine call-time coupling and *must* call our `coupling_reset`
         # after that to ensure correct "default" vs "overridden" coupling.
-        self.coupling = shell.coupling
+        self.coupling = wiring_shell.coupling
 
 
     def coupling_reset(self):
         """
         Resets call coupling behaviour to our shell's default.
         """
-        self.coupling = self._shell.coupling
+        self.coupling = self._wiring_shell.coupling
 
 
     def __getattr__(self, name):
@@ -99,10 +98,10 @@ class WiringInstance(object):
         # Either uses a tracked one or creates new one, tracking it.
 
         try:
-            return self._callables[name]
+            return self._wiring_callables[name]
         except KeyError:
-            new_callable = _callable.WiringCallable(name, self)
-            self._callables[name] = new_callable
+            new_callable = _callable.WiringCallable(self)
+            self._wiring_callables[name] = new_callable
             return new_callable
 
 

--- a/src/wires/_shell.py
+++ b/src/wires/_shell.py
@@ -39,7 +39,7 @@ class WiringShell(object):
     def __init__(self, coupling=False):
 
         self._coupling = coupling
-        self._wiring = _instance.WiringInstance(self)
+        self._wiring_instance = _instance.WiringInstance(self)
 
 
     @property
@@ -53,40 +53,40 @@ class WiringShell(object):
     @property
     def wire(self):
         """
-        Callable/callee wiring attribute.
+        Callable/callee wiring context attribute.
         """
-        return _instance.InstanceWiringActionContext(self._wiring)
+        return _instance.InstanceWiringActionContext(self._wiring_instance)
 
 
     @property
     def unwire(self):
         """
-        Callable/callee unwiring attribute.
+        Callable/callee unwiring context attribute.
         """
-        return _instance.InstanceUnwiringActionContext(self._wiring)
+        return _instance.InstanceUnwiringActionContext(self._wiring_instance)
 
 
     @property
     def coupled_call(self):
         """
-        Force caller/callee coupling when called through this.
+        Caller/callee coupled call context attribute (overrides default).
         """
-        self._wiring.coupling = True
-        return self._wiring
+        self._wiring_instance.coupling = True
+        return self._wiring_instance
 
 
     @property
     def decoupled_call(self):
         """
-        Force caller/callee decoupling when called through this.
+        Caller/callee decoupled call context attribute (overrides default).
         """
-        self._wiring.coupling = False
-        return self._wiring
+        self._wiring_instance.coupling = False
+        return self._wiring_instance
 
 
     def __getattr__(self, name):
 
-        return getattr(self._wiring, name)
+        return getattr(self._wiring_instance, name)
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Of note:
* `WiringCallable` was no longer using the `name` and `logger_name` arguments so those were removed.