### PR TITLE
Most callees are callables.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,13 +23,13 @@ Minimal usage example:
 
 .. code-block:: python
 
-    from wires import wiring, wire
+    from wires import w
 
     def my_callable():
         print('Hello from wires!')
 
-    wire.this_callable.calls_to(my_callable)
-    wiring.this_callable()
+    w.this_callable.wire(my_callable)
+    w.this_callable()
 
 
 

--- a/src/wires/_shell.py
+++ b/src/wires/_shell.py
@@ -21,22 +21,12 @@ class WiringShell(object):
     Python Wiring Shell
     """
 
-    # Wraps a Wiring Instance, cooperating with it by setting its
-    # `wire_context` attribute to support the defined usage as in:
+    # Holds the default, per-callable, `min_wirings` and `max_wirings` as well
+    # as the default caller/callee call `coupling` mode.
     #
-    # >>> ws = WiringShell()
-    # >>> ws.wire.some_callable.calls_to(<callee>)
-    # >>> ws.unwire.some_callable.calls_to(<callee>)
-    #
-    # The `calls_to` method of the Wiring Callable wires/unwires the given
-    # `<callee>` depending on its Wiring Instance `wire_context`, set by
-    # the WiringShell object.
-    #
-    # Holds the default per callable `min_wirings` and `max_wirings` as well
-    # as the default caller/callee `coupling` mode:
-    # - `min_wirings` and `max_wirings` are used by the instance at wire-time.
-    # - `coupling` mode is used by the instance at call-time and can be
-    #   overridden (again, at call-time), via `couple` / `decouple`.
+    # Wraps a Wiring Instance, cooperating with it by setting its `coupling`
+    # attribute to support call-time caller/callee coupling overriding, while
+    # delegating attribute access to expose the Wiring Instance behaviour.
 
     def __init__(self, min_wirings=None, max_wirings=None, coupling=False):
 

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -12,11 +12,11 @@ API test driver mixin.
 
 from __future__ import absolute_import
 
-from . import mixin_test_callees
+from . import mixin_test_callables
 
 
 
-class TestWiresAPIMixin(mixin_test_callees.TestCalleesMixin):
+class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
 
     """
     Drives Wires API tests requiring mixed class to:
@@ -90,16 +90,16 @@ class TestWiresAPIMixin(mixin_test_callees.TestCalleesMixin):
         """
         Wiring a callable works.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
 
     def test_wiring_unwiring_works(self):
         """
         Wiring and then unwiring same callable works.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.unwire(self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.unwire(self.returns_42_callable)
 
 
     def test_unwiring_unknown_callable_raises_value_error(self):
@@ -109,7 +109,7 @@ class TestWiresAPIMixin(mixin_test_callees.TestCalleesMixin):
         - Starts with "unknown function ".
         """
         with self.assertRaises(ValueError) as cm:
-            self.w.this.unwire(self.returns_42_callee)
+            self.w.this.unwire(self.returns_42_callable)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -126,8 +126,8 @@ class TestWiresAPIMixin(mixin_test_callees.TestCalleesMixin):
         Wiring/unwiring via indexing works.
         """
         name = 'name'
-        self.w[name].wire(self.returns_42_callee)
-        self.w[name].unwire(self.returns_42_callee)
+        self.w[name].wire(self.returns_42_callable)
+        self.w[name].unwire(self.returns_42_callable)
 
 
     def _assert_exception_arg(self, cm, expected):
@@ -142,7 +142,7 @@ class TestWiresAPIMixin(mixin_test_callees.TestCalleesMixin):
         Wiring at the instance level raises RuntimeError.
         """
         with self.assertRaises(RuntimeError) as cm:
-            self.w.some_callable.calls_to(self.returns_42_callee)
+            self.w.some_callable.calls_to(self.returns_42_callable)
 
         self._assert_exception_arg(cm, 'undefined wiring context')
 

--- a/tests/mixin_test_args.py
+++ b/tests/mixin_test_args.py
@@ -12,11 +12,11 @@ Argument passing test driver mixin.
 
 from __future__ import absolute_import
 
-from . import helpers, mixin_test_callees
+from . import helpers, mixin_test_callables
 
 
 
-class _TestWiresArgPassingMixin(mixin_test_callees.TestCalleesMixin,
+class _TestWiresArgPassingMixin(mixin_test_callables.TestCallablesMixin,
                                 helpers.CallTrackerAssertMixin):
 
     """

--- a/tests/mixin_test_callables.py
+++ b/tests/mixin_test_callables.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Test callees mixin.
+Test callables mixin.
 """
 
 
@@ -16,34 +16,34 @@ from . import helpers
 
 
 
-class TestCalleesMixin(object):
+class TestCallablesMixin(object):
 
     """
-    Holds test callees.
+    Holds test callables.
     """
 
     @staticmethod
-    def returns_42_callee():
+    def returns_42_callable():
 
         return 42
 
 
     @staticmethod
-    def returns_None_callee():
+    def returns_None_callable():
 
         return None
 
 
     THE_EXCEPTION = ValueError('bad value detail')
 
-    def raises_exception_callee(self):
+    def raises_exception_callable(self):
 
         raise self.THE_EXCEPTION
 
 
-    def unwire_call(self, callee):
+    def unwire_call(self, callable_):
 
-        self.w.this.unwire(callee)
+        self.w.this.unwire(callable_)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/mixin_test_coupling.py
+++ b/tests/mixin_test_coupling.py
@@ -12,11 +12,11 @@ Caller/callee coupling test driver mixin.
 
 from __future__ import absolute_import
 
-from . import mixin_test_callees
+from . import mixin_test_callables
 
 
 
-class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
+class TestCallerCalleeCouplingMixin(mixin_test_callables.TestCallablesMixin):
 
     """
     Drives Wires caller/callee coupling tests requiring mixed class to:
@@ -30,8 +30,8 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         Default uncoupled test: return a list of (<exception>, <result>), per-
         callee tuple.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         result = self.w.this()
 
         self.assertEqual(len(result), 1)
@@ -43,12 +43,12 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         Default uncoupled test: return a list of (<exception>, <result>), per-
         callee tuple.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.wire(self.raises_exception_callee)
-        self.w.this.wire(self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.raises_exception_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.raises_exception_callable)
+        self.w.this.wire(self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.raises_exception_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         result = self.w.this()
 
         self.assertEqual(len(result), 3)
@@ -61,8 +61,8 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         """
         Wire a callable, call it forcing coupling.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         result = self.w.couple.this()
 
         self.assertEqual(len(result), 1)
@@ -73,12 +73,12 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         """
         Wire a callable three times: the second one raises an exception.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.wire(self.raises_exception_callee)
-        self.w.this.wire(self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.raises_exception_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.raises_exception_callable)
+        self.w.this.wire(self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.raises_exception_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
         with self.assertRaises(RuntimeError) as cm:
             self.w.couple.this()
@@ -93,8 +93,8 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         """
         Wire a callable, call it forcing coupling.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         result = self.w.decouple.this()
 
         self.assertEqual(len(result), 1)
@@ -105,12 +105,12 @@ class TestCallerCalleeCouplingMixin(mixin_test_callees.TestCalleesMixin):
         """
         Wire a callable three times: the second one raises an exception.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.wire(self.raises_exception_callee)
-        self.w.this.wire(self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.raises_exception_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.raises_exception_callable)
+        self.w.this.wire(self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.raises_exception_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
         result = self.w.decouple.this()
 

--- a/tests/test_coupling_custom.py
+++ b/tests/test_coupling_custom.py
@@ -16,36 +16,36 @@ import unittest
 
 from wires import Wiring
 
-from . import mixin_test_callees
+from . import mixin_test_callables
 
 
 
-class _TestWiresCouplingMixin(mixin_test_callees.TestCalleesMixin):
+class _TestWiresCouplingMixin(mixin_test_callables.TestCallablesMixin):
 
     """
     Caller/callee custom coupling tests for Wires instances.
     """
 
-    def wire_returns_42_callee(self):
+    def wire_returns_42_callable(self):
 
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
-
-
-    def wire_raises_exeption_callee(self):
-
-        self.w.this.wire(self.raises_exception_callee)
-        self.addCleanup(self.unwire_call, self.raises_exception_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
 
-    def wire_three_callees_2nd_one_failing(self):
+    def wire_raises_exeption_callable(self):
 
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.wire(self.raises_exception_callee)
-        self.w.this.wire(self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.returns_None_callee)
-        self.addCleanup(self.unwire_call, self.raises_exception_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.raises_exception_callable)
+        self.addCleanup(self.unwire_call, self.raises_exception_callable)
+
+
+    def wire_three_callables_2nd_one_failing(self):
+
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.raises_exception_callable)
+        self.w.this.wire(self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.returns_None_callable)
+        self.addCleanup(self.unwire_call, self.raises_exception_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
 
 
@@ -62,7 +62,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_default_coupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.this()
 
@@ -72,7 +72,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_default_coupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.this()
@@ -84,7 +84,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_default_coupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.this()
@@ -97,7 +97,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_coupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.couple.this()
 
@@ -107,7 +107,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_coupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.couple.this()
@@ -119,7 +119,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_coupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.couple.this()
@@ -132,7 +132,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_decoupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.decouple.this()
 
@@ -142,7 +142,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_decoupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         result = self.w.decouple.this()
 
@@ -152,7 +152,7 @@ class TestWiresCouplingTrue(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_decoupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         result = self.w.decouple.this()
 
@@ -176,7 +176,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_default_decoupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.this()
 
@@ -186,7 +186,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_default_decoupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         result = self.w.this()
 
@@ -196,7 +196,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_default_decoupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         result = self.w.this()
 
@@ -208,7 +208,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_coupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.couple.this()
 
@@ -218,7 +218,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_coupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.couple.this()
@@ -230,7 +230,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_coupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         with self.assertRaises(RuntimeError) as cm:
             _ = self.w.couple.this()
@@ -243,7 +243,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_decoupled_call(self):
 
-        self.wire_returns_42_callee()
+        self.wire_returns_42_callable()
 
         result = self.w.decouple.this()
 
@@ -253,7 +253,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_decoupled_fail(self):
 
-        self.wire_raises_exeption_callee()
+        self.wire_raises_exeption_callable()
 
         result = self.w.decouple.this()
 
@@ -263,7 +263,7 @@ class TestWiresCouplingFalse(_TestWiresCouplingMixin, unittest.TestCase):
 
     def test_wire_wire_wire_decoupled_fail(self):
 
-        self.wire_three_callees_2nd_one_failing()
+        self.wire_three_callables_2nd_one_failing()
 
         result = self.w.decouple.this()
 

--- a/tests/test_minmaxwirings_instance.py
+++ b/tests/test_minmaxwirings_instance.py
@@ -16,11 +16,11 @@ import unittest
 
 from wires import Wiring
 
-from . import mixin_test_callees
+from . import mixin_test_callables
 
 
 
-class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
+class TestInstanceMinMaxWirings(mixin_test_callables.TestCallablesMixin,
                                unittest.TestCase):
 
     """
@@ -69,8 +69,8 @@ class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         """
         w = Wiring(min_wirings=None, max_wirings=None)
 
-        w.this.wire(self.returns_42_callee)
-        w.this.unwire(self.returns_42_callee)
+        w.this.wire(self.returns_42_callable)
+        w.this.unwire(self.returns_42_callable)
 
 
     def test_min_1_wire_unwire_raises_runtime_error(self):
@@ -79,9 +79,9 @@ class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         """
         w = Wiring(min_wirings=1)
 
-        w.this.wire(self.returns_42_callee)
+        w.this.wire(self.returns_42_callable)
         with self.assertRaises(RuntimeError) as cm:
-            w.this.unwire(self.returns_42_callee)
+            w.this.unwire(self.returns_42_callable)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -94,9 +94,9 @@ class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         """
         w = Wiring(max_wirings=1)
 
-        w.this.wire(self.returns_42_callee)
+        w.this.wire(self.returns_42_callable)
         with self.assertRaises(RuntimeError) as cm:
-            w.this.wire(self.returns_42_callee)
+            w.this.wire(self.returns_42_callable)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -123,7 +123,7 @@ class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         """
         w = Wiring(min_wirings=1)
 
-        w.this.wire(self.returns_42_callee)
+        w.this.wire(self.returns_42_callable)
         result = w.this()
 
         self.assertEqual(len(result), 1)
@@ -131,7 +131,7 @@ class TestInstanceMinMaxWirings(mixin_test_callees.TestCalleesMixin,
 
 
 
-class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
+class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
                                 unittest.TestCase):
 
     """
@@ -222,14 +222,14 @@ class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         Wiring then unwiring with min_wirings=1 raises a RuntimeError.
         """
         self.w.this.min_wirings = 1
-        self.w.this.wire(self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         self.addCleanup(self.reset_min_max_wirings)
 
         with self.assertRaises(RuntimeError) as cm:
-            self.w.this.unwire(self.returns_42_callee)
+            self.w.this.unwire(self.returns_42_callable)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -241,14 +241,14 @@ class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         Wiring two callables with max_wirings=1 raises a RuntimeError.
         """
         self.w.this.max_wirings = 1
-        self.w.this.wire(self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         self.addCleanup(self.reset_min_max_wirings)
 
         with self.assertRaises(RuntimeError) as cm:
-            self.w.this.wire(self.returns_42_callee)
+            self.w.this.wire(self.returns_42_callable)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -275,10 +275,10 @@ class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
         Calling a wired callable with min_wirings works.
         """
         self.w.this.min_wirings = 1
-        self.w.this.wire(self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
         self.addCleanup(self.reset_min_max_wirings)
 
         result = self.w.this()
@@ -289,10 +289,10 @@ class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
 
     def test_wire_min_2_raises_value_error(self):
         """
-        Setting min_wirings < wired callees raises ValueError.
+        Setting min_wirings < wired callables raises ValueError.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
         with self.assertRaises(ValueError) as cm:
             self.w.this.min_wirings = 2
@@ -304,12 +304,12 @@ class TestCallableMinMaxWirings(mixin_test_callees.TestCalleesMixin,
 
     def test_wire_wire_max_1_raises_value_error(self):
         """
-        Setting min_wirings < wired callees raises ValueError.
+        Setting min_wirings < wired callables raises ValueError.
         """
-        self.w.this.wire(self.returns_42_callee)
-        self.w.this.wire(self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
-        self.addCleanup(self.unwire_call, self.returns_42_callee)
+        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
+        self.addCleanup(self.unwire_call, self.returns_42_callable)
 
         with self.assertRaises(ValueError) as cm:
             self.w.this.max_wirings = 1


### PR DESCRIPTION
Update code and tests such that "callable" is used instead in most places; "callee" is kept only in the context of actual run-time calling where a caller calls a callee.

Also updated README to reflect API changes in #24.
