### PR TITLE
Refactor tests

### DIFF
--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -90,16 +90,16 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         """
         Wiring a callable works.
         """
-        self.w.this.wire(self.returns_42_callable)
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
 
 
     def test_wiring_unwiring_works(self):
         """
         Wiring and then unwiring same callable works.
         """
-        self.w.this.wire(self.returns_42_callable)
-        self.w.this.unwire(self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
+        self.w.this.unwire(self.returns_42)
 
 
     def test_unwiring_unknown_callable_raises_value_error(self):
@@ -109,7 +109,7 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         - Starts with "unknown function ".
         """
         with self.assertRaises(ValueError) as cm:
-            self.w.this.unwire(self.returns_42_callable)
+            self.w.this.unwire(self.returns_42)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -126,8 +126,8 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         Wiring/unwiring via indexing works.
         """
         name = 'name'
-        self.w[name].wire(self.returns_42_callable)
-        self.w[name].unwire(self.returns_42_callable)
+        self.w[name].wire(self.returns_42)
+        self.w[name].unwire(self.returns_42)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/mixin_test_callables.py
+++ b/tests/mixin_test_callables.py
@@ -22,11 +22,11 @@ class TestCallablesMixin(object):
     Holds test callables.
     """
 
-    THE_EXCEPTION = ValueError('test exception value error message')
-    raises_exception_callable = helpers.CallTracker(raises=THE_EXCEPTION)
+    EXCEPTION = ValueError('test exception value error message')
+    raises_exception = helpers.CallTracker(raises=EXCEPTION)
 
-    returns_42_callable = helpers.CallTracker(returns=42)
-    returns_none_callable = helpers.CallTracker(returns=None)
+    returns_42 = helpers.CallTracker(returns=42)
+    returns_none = helpers.CallTracker(returns=None)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/mixin_test_coupling.py
+++ b/tests/mixin_test_coupling.py
@@ -69,7 +69,7 @@ def _test_name(wa, ctao, call):
 
 def _generate_returns_42_test(test_class, wa, ctao, returns, ignore_failures):
 
-    wire = [test_class.returns_42_callable]
+    wire = [test_class.returns_42]
     raises = None
     result = [(None, 42)] if returns else None
     call_counts = [1]
@@ -83,13 +83,13 @@ def _generate_returns_42_test(test_class, wa, ctao, returns, ignore_failures):
 
 def _generate_raises_exc_test(test_class, wa, ctao, returns, ignore_failures):
 
-    wire = [test_class.raises_exception_callable]
+    wire = [test_class.raises_exception]
     if returns:
         if ignore_failures:
-            result = [(test_class.THE_EXCEPTION, None)] if returns else None
+            result = [(test_class.EXCEPTION, None)] if returns else None
             raises = None
         else:
-            result = ((test_class.THE_EXCEPTION, None),) if returns else None
+            result = ((test_class.EXCEPTION, None),) if returns else None
             raises = RuntimeError
     else:
         result = None
@@ -106,16 +106,16 @@ def _generate_raises_exc_test(test_class, wa, ctao, returns, ignore_failures):
 def _generate_2in3_raises_test(test_class, wa, ctao, returns, ignore_failures):
 
     wire = [
-        test_class.returns_42_callable,
-        test_class.raises_exception_callable,
-        test_class.returns_none_callable,
+        test_class.returns_42,
+        test_class.raises_exception,
+        test_class.returns_none,
     ]
     if returns:
         if ignore_failures:
-            result = [(None, 42), (test_class.THE_EXCEPTION, None), (None, None)]
+            result = [(None, 42), (test_class.EXCEPTION, None), (None, None)]
             raises = None
         else:
-            result = ((None, 42), (test_class.THE_EXCEPTION, None),)
+            result = ((None, 42), (test_class.EXCEPTION, None),)
             raises = RuntimeError
     else:
         result = None

--- a/tests/mixin_test_coupling.py
+++ b/tests/mixin_test_coupling.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Caller/callee coupling test driver mixin.
+Caller/callee call time coupling test driver mixin.
 """
 
 
@@ -14,25 +14,11 @@ from __future__ import absolute_import
 
 from wires import Wiring
 
-from . import helpers
+from . import mixin_test_callables
 
 
 
-class WireAssertCouplingTestMixin(object):
-
-    """
-    Wiring and Assertion mixin for coupling tests.
-    """
-
-    EXCEPTION = ValueError('test exception message')
-
-    return_42 = helpers.CallTracker(returns=42)
-    return_none = helpers.CallTracker(returns=None)
-    raise_exception = helpers.CallTracker(raises=EXCEPTION)
-
-
-
-class TestCouplingMixin(WireAssertCouplingTestMixin):
+class TestCouplingMixin(mixin_test_callables.TestCallablesMixin):
 
     """
     Drives Wires call coupling tests.
@@ -83,7 +69,7 @@ def _test_name(wa, ctao, call):
 
 def _generate_returns_42_test(test_class, wa, ctao, returns, ignore_failures):
 
-    wire = [test_class.return_42]
+    wire = [test_class.returns_42_callable]
     raises = None
     result = [(None, 42)] if returns else None
     call_counts = [1]
@@ -97,13 +83,13 @@ def _generate_returns_42_test(test_class, wa, ctao, returns, ignore_failures):
 
 def _generate_raises_exc_test(test_class, wa, ctao, returns, ignore_failures):
 
-    wire = [test_class.raise_exception]
+    wire = [test_class.raises_exception_callable]
     if returns:
         if ignore_failures:
-            result = [(test_class.EXCEPTION, None)] if returns else None
+            result = [(test_class.THE_EXCEPTION, None)] if returns else None
             raises = None
         else:
-            result = ((test_class.EXCEPTION, None),) if returns else None
+            result = ((test_class.THE_EXCEPTION, None),) if returns else None
             raises = RuntimeError
     else:
         result = None
@@ -120,16 +106,16 @@ def _generate_raises_exc_test(test_class, wa, ctao, returns, ignore_failures):
 def _generate_2in3_raises_test(test_class, wa, ctao, returns, ignore_failures):
 
     wire = [
-        test_class.return_42,
-        test_class.raise_exception,
-        test_class.return_none,
+        test_class.returns_42_callable,
+        test_class.raises_exception_callable,
+        test_class.returns_none_callable,
     ]
     if returns:
         if ignore_failures:
-            result = [(None, 42), (test_class.EXCEPTION, None), (None, None)]
+            result = [(None, 42), (test_class.THE_EXCEPTION, None), (None, None)]
             raises = None
         else:
-            result = ((None, 42), (test_class.EXCEPTION, None),)
+            result = ((None, 42), (test_class.THE_EXCEPTION, None),)
             raises = RuntimeError
     else:
         result = None

--- a/tests/test_coupling_custom.py
+++ b/tests/test_coupling_custom.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import sys
 import unittest
 
-from . import mixin_test_coupling
+from . import mixin_test_callables, mixin_test_coupling
 
 
 
@@ -43,7 +43,7 @@ def _generate_test_classes():
     ]
 
     base_classes = (
-        mixin_test_coupling.WireAssertCouplingTestMixin,
+        mixin_test_callables.TestCallablesMixin,
         unittest.TestCase,
     )
 

--- a/tests/test_minmaxwirings_instance.py
+++ b/tests/test_minmaxwirings_instance.py
@@ -69,8 +69,8 @@ class TestInstanceMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         w = Wiring(min_wirings=None, max_wirings=None)
 
-        w.this.wire(self.returns_42_callable)
-        w.this.unwire(self.returns_42_callable)
+        w.this.wire(self.returns_42)
+        w.this.unwire(self.returns_42)
 
 
     def test_min_1_wire_unwire_raises_runtime_error(self):
@@ -79,9 +79,9 @@ class TestInstanceMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         w = Wiring(min_wirings=1)
 
-        w.this.wire(self.returns_42_callable)
+        w.this.wire(self.returns_42)
         with self.assertRaises(RuntimeError) as cm:
-            w.this.unwire(self.returns_42_callable)
+            w.this.unwire(self.returns_42)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -94,9 +94,9 @@ class TestInstanceMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         w = Wiring(max_wirings=1)
 
-        w.this.wire(self.returns_42_callable)
+        w.this.wire(self.returns_42)
         with self.assertRaises(RuntimeError) as cm:
-            w.this.wire(self.returns_42_callable)
+            w.this.wire(self.returns_42)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -123,7 +123,7 @@ class TestInstanceMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         w = Wiring(min_wirings=1)
 
-        w.this.wire(self.returns_42_callable)
+        w.this.wire(self.returns_42)
         result = w.this()
 
         self.assertIsNone(result)
@@ -221,14 +221,14 @@ class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         Wiring then unwiring with min_wirings=1 raises a RuntimeError.
         """
         self.w.this.min_wirings = 1
-        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
         self.addCleanup(self.reset_min_max_wirings)
 
         with self.assertRaises(RuntimeError) as cm:
-            self.w.this.unwire(self.returns_42_callable)
+            self.w.this.unwire(self.returns_42)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -240,14 +240,14 @@ class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         Wiring two callables with max_wirings=1 raises a RuntimeError.
         """
         self.w.this.max_wirings = 1
-        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
         self.addCleanup(self.reset_min_max_wirings)
 
         with self.assertRaises(RuntimeError) as cm:
-            self.w.this.wire(self.returns_42_callable)
+            self.w.this.wire(self.returns_42)
 
         exception_args = cm.exception.args
         self.assertEqual(len(exception_args), 1)
@@ -274,10 +274,10 @@ class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         Calling a wired callable with min_wirings works.
         """
         self.w.this.min_wirings = 1
-        self.w.this.wire(self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
 
         # clean up in the reverse order, otherwise unwiring fails
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
         self.addCleanup(self.reset_min_max_wirings)
 
         result = self.w.this()
@@ -289,8 +289,8 @@ class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         Setting min_wirings < wired callables raises ValueError.
         """
-        self.w.this.wire(self.returns_42_callable)
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
 
         with self.assertRaises(ValueError) as cm:
             self.w.this.min_wirings = 2
@@ -304,10 +304,10 @@ class TestCallableMinMaxWirings(mixin_test_callables.TestCallablesMixin,
         """
         Setting min_wirings < wired callables raises ValueError.
         """
-        self.w.this.wire(self.returns_42_callable)
-        self.w.this.wire(self.returns_42_callable)
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
-        self.addCleanup(self.w.this.unwire, self.returns_42_callable)
+        self.w.this.wire(self.returns_42)
+        self.w.this.wire(self.returns_42)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
 
         with self.assertRaises(ValueError) as cm:
             self.w.this.max_wirings = 1


### PR DESCRIPTION
Coupling tests were unnecessarily creating a test class just like TestCallablesMixin which is now used all around.