### PR TITLE
Wiring instances now support callable attribute deletion.

### DIFF
--- a/src/wires/_instance.py
+++ b/src/wires/_instance.py
@@ -79,4 +79,11 @@ class WiringInstance(object):
             return new_callable
 
 
+    def __delattr__(self, name):
+
+        # Deletes the tracked callable object.
+
+        del self._wiring_callables[name]
+
+
 # ----------------------------------------------------------------------------

--- a/src/wires/_shell.py
+++ b/src/wires/_shell.py
@@ -92,9 +92,16 @@ class WiringShell(object):
 
     def __getattr__(self, name):
         """
-        Attribute based access to Instance Callables.
+        Attribute based access to Callables.
         """
         return getattr(self._wiring_instance, name)
+
+
+    def __delattr__(self, name):
+        """
+        Deletes Callable attributes.
+        """
+        delattr(self._wiring_instance, name)
 
 
     def __getitem__(self, name):

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -130,4 +130,12 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         self.w[name].unwire(self.returns_42)
 
 
+    def test_create_and_delete_callable(self):
+        """
+        Creating and deleting a callable works.
+        """
+        self.w.this.wire(self.returns_42)
+        del self.w.this
+
+
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #48.