### PR TITLE
WiringCallable now has a .wirings attribute.

### DIFF
--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -46,6 +46,15 @@ class WiringCallable(object):
 
 
     @property
+    def wirings(self):
+        """
+        List of wired (<callable>, <wire-time-args>, <wire-time-kwargs>) tuples,
+        where <wire-time-args> is a tuple and <wire-time-kwargs> is a dict.
+        """
+        return list(self._wirings)
+
+
+    @property
     def min_wirings(self):
         """
         Minimum number of allowed wirings. None means no limit.

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -148,6 +148,26 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         self.assertEqual(self.w.this.__name__, 'this')
 
 
+    def test_callables_wiring_attribute(self):
+        """
+        Created callables have a `.wirings` attribute that is a list of
+        (<wired-callable>, <wired-args-tuple>, <wired-kwargs-dict>).
+        """
+        self.w.this.wire(self.returns_42)
+        self.addCleanup(self.w.this.unwire, self.returns_42)
+
+        wirings = self.w.this.wirings
+
+        self.assertEqual(len(wirings), 1)
+
+        wired_callable, wired_args, wired_kwargs = wirings[0]
+        self.assertIs(wired_callable, self.returns_42)
+        self.assertIsInstance(wired_args, tuple)
+        self.assertEqual(wired_args, ())
+        self.assertIsInstance(wired_kwargs, dict)
+        self.assertEqual(wired_kwargs, {})
+
+
     def test_iteration_works(self):
         """
         Iterating over a Wiring instance produces its callables.


### PR DESCRIPTION
Notes:
* `.wirings` is a read-only attribute.
* Builds a copy of the private `._wirings` attribute which is a list of `(<wired-callable>, <wire-time-args-tuple>, <wire-time-kwargs-dict>)`.

Addresses #28 while discarding the proposed `.wiring_count` attribute.