### PR TITLE
Exclude __weakref__ entries in reference documentation.

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -19,6 +19,7 @@ Wiring
 .. automodule:: wires._wiring
    :members:
    :special-members: 
+   :exclude-members: __weakref__
 
 
 
@@ -28,5 +29,6 @@ Wiring Callable
 .. automodule:: wires._callable
    :members:
    :special-members: 
+   :exclude-members: __weakref__
 
 


### PR DESCRIPTION
Minor contribution to #16.