### PR TITLE
Per callable coupling settings

### DIFF
--- a/pylintrc-tests
+++ b/pylintrc-tests
@@ -1,7 +1,6 @@
 [BASIC]
 good-names=w,
            cm,
-           wa,
            setUp,
            tearDown
 

--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -144,12 +144,24 @@ class WiringCallable(object):
         return self._effective_setting('returns')
 
 
+    @returns.setter
+    def returns(self, value):
+
+        self._callable_settings['returns'] = value
+
+
     @property
     def ignore_failures(self):
         """
         If False, stops calling wired callables on the first raised exception.
         """
         return self._effective_setting('ignore_failures')
+
+
+    @ignore_failures.setter
+    def ignore_failures(self, value):
+
+        self._callable_settings['ignore_failures'] = value
 
 
     def wire(self, function, *args, **kwargs):

--- a/tests/mixin_test_coupling.py
+++ b/tests/mixin_test_coupling.py
@@ -185,41 +185,6 @@ def _create_returns_42_test(test_class, wa, pca, ctao):
 
 
 
-def _create_raises_exc_test(test_class, wa, pca, ctao):
-
-    # Adds the second test case to `test_class`.
-    # - `wa`: instance initialization arguments.
-    # - `ctao`: call time argument overrides.
-
-    # The effective `returns` and `ignore_failures` values.
-    returns = _effective_returns(wa, pca, ctao)
-    ignore_failures = _effective_ignore_failures(wa, pca, ctao)
-
-    wire = [test_class.raises_exception]
-    # Expected `result` and `raises` depend on `returns` and `ignore_failures`.
-    if returns:
-        if ignore_failures:
-            result = [(test_class.EXCEPTION, None)] if returns else None
-            raises = None
-        else:
-            # `raises` set to an Exception class, `result` is the expected
-            # exception instance arguments: always a tuple.
-            result = ((test_class.EXCEPTION, None),) if returns else None
-            raises = RuntimeError
-    else:
-        result = None
-        raises = None
-    call_counts = [1]
-
-    # Create and add the test to the class.
-    setattr(
-        test_class,
-        _test_method_name(wa, pca, ctao, 'case2_raises_exception'),
-        _create_test_method(wa, wire, pca, ctao, raises, result, call_counts),
-    )
-
-
-
 def _create_2in3_raises_test(test_class, wa, pca, ctao):
 
     # Adds the thrid test case to `test_class`.
@@ -231,17 +196,17 @@ def _create_2in3_raises_test(test_class, wa, pca, ctao):
     ignore_failures = _effective_ignore_failures(wa, pca, ctao)
 
     wire = [
-        test_class.returns_42,
-        test_class.raises_exception,
         test_class.returns_none,
+        test_class.raises_exception,
+        test_class.returns_42,
     ]
     # Expected `result` and `raises` depend on `returns` and `ignore_failures`.
     if returns:
         if ignore_failures:
-            result = [(None, 42), (test_class.EXCEPTION, None), (None, None)]
+            result = [(None, None), (test_class.EXCEPTION, None), (None, 42)]
             raises = None
         else:
-            result = ((None, 42), (test_class.EXCEPTION, None),)
+            result = ((None, None), (test_class.EXCEPTION, None),)
             raises = RuntimeError
     else:
         result = None
@@ -305,7 +270,6 @@ def generate_tests(test_class, wiring_args_filter=None):
         for pca in call_coupling_arg_combinations:
             for ctao in call_coupling_arg_combinations:
                 _create_returns_42_test(test_class, wa, pca, ctao)
-                _create_raises_exc_test(test_class, wa, pca, ctao)
                 _create_2in3_raises_test(test_class, wa, pca, ctao)
 
 

--- a/tests/mixin_test_coupling.py
+++ b/tests/mixin_test_coupling.py
@@ -6,7 +6,7 @@
 # ----------------------------------------------------------------------------
 
 """
-Caller/callee call time coupling test driver mixin.
+Caller/callee call-time coupling test driver mixin.
 """
 
 
@@ -20,10 +20,10 @@ from . import mixin_test_callables
 
 # Overview
 # --------
-# Caller/callee call time coupling behaviour is defined by two boolean
+# Caller/callee call-time coupling behaviour is defined by two boolean
 # parameters: `returns` and `ignore_failures`.
 #
-# Depending on their values, call time behaviour is:
+# Depending on their values, call-time behaviour is:
 #
 #                | ignore_failures=False       | ignore_failures=True
 # ---------------+-----------------------------+------------------------------
@@ -44,44 +44,49 @@ from . import mixin_test_callables
 #
 # Usage
 # -----
-# The call time coupling parameters can be used at two levels:
+# The call-time coupling parameters can be used at three levels:
 #
 # 1. When initializng a `Wiring` instance, via its initializer arguments:
 #
 #    >>> w = Wiring(returns=<bool>, ignore_failures=<bool>)
 #
-# 2. At call time, overriding the instance's default behaviour:
+# 2. As a per-Callable setting:
+#
+#    >>> w.some_callable.returns = <bool>
+#    >>> w.some_callable.ignore_failures = <bool>
+#
+# 3. At call-time, overriding the instance/callable's default behaviour:
 #
 #    >>> w(returns=<bool>, ignore_failures=<bool>).some_callable()
 #
 #
 # About the tests
 # ---------------
-# Testing combinations of initialization time coupling arguments vs. call time
-# overriding arguments vs. single-/multi-/failing-/non-failing- wirings is non
-# trivial and quickly leads to a combinatorial explosion.
+# Testing combinations of initialization-time coupling arguments vs. per-
+# callable overriding arguments vs. call-time overriding arguments vs. single-/
+# /multi-/failing-/non-failing- wirings is non trivial and quickly leads to a
+# combinatorial explosion.
 #
 # For that reason, call coupling tests are generated/synthesized instead of
 # individually hand coded.
 #
-# The base idea is to run three test cases on every possible scenario:
+# The base idea is to run two test cases on every possible scenario:
 #
 # Case #1 - Wires a single callable that returns 42.
-# Case #2 - Wires a single callable that raises a known exception.
-# Case #3 - Wires three callables:
-#           - The first returns 42.
+# Case #2 - Wires three callables:
+#           - The first returns None.
 #           - The second raises a known exception.
-#           - The third returns None.
+#           - The third returns 42.
 #
 # This module contains two sets of objects:
-# - Functions that add combinations of the three-test-set to a given class.
+# - Functions that add combinations of the two-test-set to a given class.
 # - A Mixin class used with the bundled shared Wiring instance tests as well
 #   as with a non-customized Wiring instance (like most other test Mixins are
 #   used).
 
 
 
-def _create_test_method(wiring_args, wire, pca, ctao, raises, result, call_counts):
+def _create_test_method(ita, wirings, pca, cta, raises, result, call_counts):
 
     def call_coupling_test_method(self):
         """
@@ -89,15 +94,15 @@ def _create_test_method(wiring_args, wire, pca, ctao, raises, result, call_count
         """
 
         # Replace the test class Wiring instance with a custom initialized one.
-        if wiring_args:
-            self.w = Wiring(**wiring_args)
+        if ita:
+            self.w = Wiring(**ita)
 
         # Set per-callable settings.
         for callable_setting, callable_value in pca.items():
             setattr(self.w.this, callable_setting, callable_value)
 
         # Wire all wirings in `wire`, assumed to be helpers.CallTrackers.
-        for call_tracker in wire:
+        for call_tracker in wirings:
             call_tracker.reset()
             self.w.this.wire(call_tracker)
             self.addCleanup(self.w.this.unwire, call_tracker)
@@ -105,13 +110,13 @@ def _create_test_method(wiring_args, wire, pca, ctao, raises, result, call_count
         # Do the actual call with call-time argument overriding.
         if raises:
             with self.assertRaises(raises) as cm:
-                self.w(**ctao).this()
+                self.w(**cta).this()
             actual_result = cm.exception.args
         else:
-            actual_result = self.w(**ctao).this()
+            actual_result = self.w(**cta).this()
 
         # Assert expected call counts.
-        actual_call_counts = [w.call_count for w in wire]
+        actual_call_counts = [w.call_count for w in wirings]
         self.assertEqual(call_counts, actual_call_counts, 'call count mismatch')
 
         # Assert expected result.
@@ -121,57 +126,61 @@ def _create_test_method(wiring_args, wire, pca, ctao, raises, result, call_count
 
 
 
-def _test_method_name(wa, pca, ctao, call):
+def _test_method_name(ita, pca, cta, call):
 
     # Test method names include instantiation-time argument names and values,
-    # as well as call-time override argument names and values.
+    # as well as per-callable arguments and call-time overriding argument names
+    # and values.
 
     def _dict_to_method_name_part(arg_dict):
         return '_'.join('%s_%s' % (k, v) for k, v in arg_dict.items())
 
-    return 'test_wa_%s_pca_%s_ctao_%s_%s' % (
-        _dict_to_method_name_part(wa),
+    return 'test_ita_%s_pca_%s_cta_%s_%s' % (
+        _dict_to_method_name_part(ita),
         _dict_to_method_name_part(pca),
-        _dict_to_method_name_part(ctao),
+        _dict_to_method_name_part(cta),
         call,
     )
 
 
 
-def _effective_returns(wa, pca, ctao):
+def _effective_returns(ita, pca, cta):
 
-    # Return the effective value of `returns` based on instantiation time
-    # argument dict `wa` and call time override dict `ctao`, considering that
-    # the default instantiation time value is `False`.
+    # Return the effective value of `returns` based on instantiation-time
+    # argument dict `ita`, per-callable argument dict `pca` and call-time
+    # override dict `cta`, considering that the default, instantiation time,
+    # value is `False`.
 
-    return ctao.get('returns', pca.get('returns', wa.get('returns', False)))
+    return cta.get('returns', pca.get('returns', ita.get('returns', False)))
 
 
 
-def _effective_ignore_failures(wa, pca, ctao):
+def _effective_ignore_failures(ita, pca, cta):
 
-    # Return the effective value of `ingore_failures` based on instantiation
-    # time argument dict `wa` and call time override dict `ctao`, considering
-    # that the default instantiation time value is `True`.
+    # Return the effective value of `ignore_failures` based on instantiation-
+    # time argument dict `ita`, per-callable argument dict `pca` and call-time
+    # override dict `cta`, considering that the default, instantiation time,
+    # value is `True`.
 
-    return ctao.get(
+    return cta.get(
         'ignore_failures',
-        pca.get('ignore_failures', wa.get('ignore_failures', True))
+        pca.get('ignore_failures', ita.get('ignore_failures', True))
     )
 
 
 
-def _create_returns_42_test(test_class, wa, pca, ctao):
+def _create_returns_42_test(test_class, ita, pca, cta):
 
     # Adds the first test case to `test_class`.
-    # - `wa`: instance initialization arguments.
-    # - `ctao`: call time argument overrides.
+    # - `ita`: instance initialization-time arguments.
+    # - `pca`: per-callable arguments
+    # - `cta`: call-time argument overrides.
 
     # The effective `returns` value.
-    returns = _effective_returns(wa, pca, ctao)
+    returns = _effective_returns(ita, pca, cta)
 
     # Expected `result` depends on `returns`; everything else is constant.
-    wire = [test_class.returns_42]
+    wirings = [test_class.returns_42]
     raises = None
     result = [(None, 42)] if returns else None
     call_counts = [1]
@@ -179,23 +188,24 @@ def _create_returns_42_test(test_class, wa, pca, ctao):
     # Create and add the test to the class.
     setattr(
         test_class,
-        _test_method_name(wa, pca, ctao, 'case1_returns_42'),
-        _create_test_method(wa, wire, pca, ctao, raises, result, call_counts),
+        _test_method_name(ita, pca, cta, 'case1_returns_42'),
+        _create_test_method(ita, wirings, pca, cta, raises, result, call_counts)
     )
 
 
 
-def _create_2in3_raises_test(test_class, wa, pca, ctao):
+def _create_2in3_raises_test(test_class, ita, pca, cta):
 
     # Adds the thrid test case to `test_class`.
-    # - `wa`: instance initialization arguments.
-    # - `ctao`: call time argument overrides.
+    # - `ita`: instance initialization-time arguments.
+    # - `pca`: per-callable arguments
+    # - `cta`: call-time argument overrides.
 
     # The effective `returns` and `ignore_failures` values.
-    returns = _effective_returns(wa, pca, ctao)
-    ignore_failures = _effective_ignore_failures(wa, pca, ctao)
+    returns = _effective_returns(ita, pca, cta)
+    ignore_failures = _effective_ignore_failures(ita, pca, cta)
 
-    wire = [
+    wirings = [
         test_class.returns_none,
         test_class.raises_exception,
         test_class.returns_42,
@@ -217,8 +227,8 @@ def _create_2in3_raises_test(test_class, wa, pca, ctao):
     # Create and add the test to the class.
     setattr(
         test_class,
-        _test_method_name(wa, pca, ctao, 'case3_2in3_raises_exception'),
-        _create_test_method(wa, wire, pca, ctao, raises, result, call_counts)
+        _test_method_name(ita, pca, cta, 'case3_2in3_raises_exception'),
+        _create_test_method(ita, wirings, pca, cta, raises, result, call_counts)
     )
 
 
@@ -237,30 +247,31 @@ CALL_COUPLING_ARG_COMBINATIONS = [
 
 
 
-def generate_tests(test_class, wiring_args_filter=None):
+def generate_tests(test_class, ita_filter=None):
     """
     Generates three test case set combinations and adds them to `test_class`.
 
-    Considers all combinations of instantiation time and call time arguments in
-    a combinatoric product, filtering out instantiation time combinations based
-    on `wiring_args_filter`; this is used to target test generation to varying
-    "starting points".
+    Considers all combinations of Wiring instantiation time, per-callable and
+    call-time arguments in a combinatoric product, filtering out instantiation
+    time combinations based on `ita_filter`; this is used to target test
+    generation to varying "starting points".
 
-    Test case set combinations are then generated based on `wa` (instantiation
-    time arguments) and `ctao` (call time argument overrides).
+    Test case set combinations are then generated based on `ita` (instantiation-
+    time arguments), `pca` (per-callable arguments) and `cta` (call-time
+    argument overrides).
     """
     call_coupling_arg_combinations = [{}]
     call_coupling_arg_combinations.extend(CALL_COUPLING_ARG_COMBINATIONS)
 
-    for wa in call_coupling_arg_combinations:
-        if wiring_args_filter is None:
-            if wa:
-                # no wiring_args_filter: skip test sets with wiring args.
+    for ita in call_coupling_arg_combinations:
+        if ita_filter is None:
+            if ita:
+                # no ita_filter: skip test sets with wiring args.
                 continue
         else:
             skip = False
-            for arg, value in wiring_args_filter.items():
-                if wa.get(arg) != value:
+            for arg, value in ita_filter.items():
+                if ita.get(arg) != value:
                     # skip test sets with differet wiring args
                     skip = True
                     break
@@ -268,9 +279,9 @@ def generate_tests(test_class, wiring_args_filter=None):
                 continue
         # create the test methods
         for pca in call_coupling_arg_combinations:
-            for ctao in call_coupling_arg_combinations:
-                _create_returns_42_test(test_class, wa, pca, ctao)
-                _create_2in3_raises_test(test_class, wa, pca, ctao)
+            for cta in call_coupling_arg_combinations:
+                _create_returns_42_test(test_class, ita, pca, cta)
+                _create_2in3_raises_test(test_class, ita, pca, cta)
 
 
 
@@ -283,7 +294,7 @@ class TestCouplingMixin(mixin_test_callables.TestCallablesMixin):
 
 # Generate tests, considering only default instantiation time arguments.
 
-generate_tests(TestCouplingMixin, wiring_args_filter=None)
+generate_tests(TestCouplingMixin, ita_filter=None)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_coupling_custom.py
+++ b/tests/test_coupling_custom.py
@@ -28,13 +28,14 @@ from . import mixin_test_callables, mixin_test_coupling
 
 
 
-def _test_class_name(wa):
+def _test_class_name(ita):
 
-    # Test class names include instantiation-time argument names and values.
+    # Test class names include `ita` (instantiation-time argument) names and
+    # values.
 
     class_name_part = ''.join(
         '%s%s' % (str(k).capitalize(), str(v).capitalize())
-        for k, v in wa.items()
+        for k, v in ita.items()
     )
     return 'TestCoupling%s' % (class_name_part,)
 
@@ -57,10 +58,10 @@ def _generate_test_classes():
 
     this_module = sys.modules[__name__]
 
-    for wa in mixin_test_coupling.CALL_COUPLING_ARG_COMBINATIONS:
-        test_class_name = _test_class_name(wa)
+    for ita in mixin_test_coupling.CALL_COUPLING_ARG_COMBINATIONS:
+        test_class_name = _test_class_name(ita)
         test_class = type(test_class_name, base_classes, {})
-        mixin_test_coupling.generate_tests(test_class, wa)
+        mixin_test_coupling.generate_tests(test_class, ita)
         setattr(this_module, test_class_name, test_class)
 
 

--- a/tests/test_coupling_new_instance.py
+++ b/tests/test_coupling_new_instance.py
@@ -23,7 +23,7 @@ class TestWiresCoupling(mixin_use_new_instance.UseNewInstanceMixin,
                         unittest.TestCase):
 
     """
-    Call time coupling tests for Wiring instances.
+    Call-time coupling tests for Wiring instances.
     """
 
 

--- a/tests/test_coupling_shared_instance.py
+++ b/tests/test_coupling_shared_instance.py
@@ -23,7 +23,7 @@ class TestWiresCoupling(mixin_use_shared_instance.UseSharedInstanceMixin,
                         unittest.TestCase):
 
     """
-    Call time coupling tests for the shared Wiring instance.
+    Call-time coupling tests for the shared Wiring instance.
     """
 
 


### PR DESCRIPTION
Addresses the key aspect of #43, this is now valid and works:

```
>>> w = Wiring()
>>> w.some_callable.returns = True
>>> w.some_callable()
[]
```