### PR TITLE
Repurposed Callable.set_next_call_settings into a better .set.

### DIFF
--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -72,24 +72,21 @@ class WiringCallable(object):
         in future releases; it is used internally to override call-time settings.
         """
 
-        # Going with a `**kwargs` like argument would make this code simpler,
-        # but the method signature would be more opaque; we prefer explicit
-        # even though the code is longer, slower and harder (even if by a small
-        # amount) to manage.
-
         if _next_call_only is True:
             target_settings = self._calltime_settings
         else:
             target_settings = self._callable_settings
 
-        if min_wirings is not self.not_set:
-            target_settings['min_wirings'] = min_wirings
-        if max_wirings is not self.not_set:
-            target_settings['max_wirings'] = max_wirings
-        if returns is not self.not_set:
-            target_settings['returns'] = returns
-        if ignore_failures is not self.not_set:
-            target_settings['ignore_failures'] = ignore_failures
+        # Going with a `**kwargs` like argument would make this code simpler,
+        # but the method signature would be more opaque; we prefer explicit
+        # even though the code needs to repeat the argument names and work
+        # at a somewhat "meta-ish" level.
+
+        local_names = locals()
+        arg_names = ('min_wirings', 'max_wirings', 'returns', 'ignore_failures')
+        for name in arg_names:
+            if local_names[name] is not self.not_set:
+                target_settings[name] = local_names[name]
 
 
     @property

--- a/src/wires/_callable.py
+++ b/src/wires/_callable.py
@@ -55,11 +55,41 @@ class WiringCallable(object):
         return self._name
 
 
-    def set_next_call_settings(self, settings):
+    # Used as a guard for non-set arguments in the `set` method call; `None`
+    # would not be appropriate given than `min_wirings` and `max_wirings` take
+    # `None` as valid value.
+
+    not_set = object()
+
+    def set(self, min_wirings=not_set, max_wirings=not_set, returns=not_set,
+            ignore_failures=not_set, _next_call_only=False):
         """
-        Called by the instance to update call-time setting overrides.
+        Sets one or more per-callable settings.
+
+        The `not_set` defaults are used as a guard to identify non-set arguments.
+
+        The `_next_call_only` argument is considered private and may be removed
+        in future releases; it is used internally to override call-time settings.
         """
-        self._calltime_settings.update(settings)
+
+        # Going with a `**kwargs` like argument would make this code simpler,
+        # but the method signature would be more opaque; we prefer explicit
+        # even though the code is longer, slower and harder (even if by a small
+        # amount) to manage.
+
+        if _next_call_only is True:
+            target_settings = self._calltime_settings
+        else:
+            target_settings = self._callable_settings
+
+        if min_wirings is not self.not_set:
+            target_settings['min_wirings'] = min_wirings
+        if max_wirings is not self.not_set:
+            target_settings['max_wirings'] = max_wirings
+        if returns is not self.not_set:
+            target_settings['returns'] = returns
+        if ignore_failures is not self.not_set:
+            target_settings['ignore_failures'] = ignore_failures
 
 
     @property

--- a/src/wires/_wiring.py
+++ b/src/wires/_wiring.py
@@ -91,7 +91,7 @@ class Wiring(object):
             the_callable = new_callable
 
         if self._calltime_settings:
-            the_callable.set_next_call_settings(self._calltime_settings)
+            the_callable.set(_next_call_only=True, **self._calltime_settings)
             self._calltime_settings.clear()
 
         return the_callable


### PR DESCRIPTION
Addresses #58 while repurposing the `.set_next_call_settings` method that was popping out of the WiringCallable API as something foreign. The solution, for now, is using a "private argument".

Benefits:
* Better WiringCallable API names and signatures.
* More flexible WiringCallable API: implements #58.

Trade-off:
* Using a `_next_call_only` named argument; still better than the previously public `. set_next_call_settings`.