### PR TITLE
Wiring objects dir() contains callable names: implemented and tested.

### DIFF
--- a/src/wires/_wiring.py
+++ b/src/wires/_wiring.py
@@ -156,6 +156,16 @@ class Wiring(object):
         del self._callables[name]
 
 
+    def __dir__(self):
+
+        # Add our WiringCallable names to the attribute list.
+        # Note: No super(...).__dir__() on Python 2!
+
+        result = dir(super(Wiring, self))
+        result.extend(self._callables.keys())
+        return result
+
+
     def __len__(self):
         """
         Existing :class:`WiringCallable <wires._callable.WiringCallable>` count.

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -183,6 +183,20 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         self.assertEqual(created_callables, obtained_callables)
 
 
+    def test_wiring_dir(self):
+        """
+        Callable names are present in a Wiring object's dir() output.
+        """
+        self.w.callable1.wire(self.returns_42)
+        self.w.callable2.wire(self.returns_none)
+        self.addCleanup(self.w.callable1.unwire, self.returns_42)
+        self.addCleanup(self.w.callable2.unwire, self.returns_none)
+
+        dir_output = dir(self.w)
+        self.assertIn('callable1', dir_output)
+        self.assertIn('callable2', dir_output)
+
+
     def test_wiring_len(self):
         """
         No callables means len is 0.


### PR DESCRIPTION
Addresses #72.