### PR TITLE
Fix Wiring.__delattr__: delete "normal" attributes as well.

### DIFF
--- a/src/wires/_wiring.py
+++ b/src/wires/_wiring.py
@@ -151,9 +151,13 @@ class Wiring(object):
 
     def __delattr__(self, name):
         """
-        Deletes :class:`WiringCallable <wires._callable.WiringCallable>`\\s.
+        Deletes :class:`WiringCallable <wires._callable.WiringCallable>`\\s
+        or any other attributes.
         """
-        del self._callables[name]
+        try:
+            del self._callables[name]
+        except KeyError:
+            super(Wiring, self).__delattr__(name)
 
 
     def __dir__(self):

--- a/tests/mixin_test_api.py
+++ b/tests/mixin_test_api.py
@@ -301,6 +301,30 @@ class TestWiresAPIMixin(mixin_test_callables.TestCallablesMixin):
         self.assertTrue(repr_str.endswith(ending), 'bad repr end')
 
 
+    def test_wiring_set_del_regular_attr_works(self):
+        """
+        Setting a Wiring attribute to something, then deleting it, then
+        accessing it, creates a "normal" callable object, as expected.
+        """
+        self.w.what_for = 42
+        self.assertEqual(self.w.what_for, 42)
+
+        del self.w.what_for
+        self.assertTrue(callable(self.w.what_for), 'non-callable attribute')
+
+
+    def test_wiring_del_nonsuch_attr_raises_attribute_error(self):
+        """
+        Deleting a non-existing Wiring attribute raises an AttributeError.
+        """
+        with self.assertRaises(AttributeError) as cm:
+            del self.w.no_such_attribute
+
+        exception_args = cm.exception.args
+        self.assertEqual(len(exception_args), 1)
+        self.assertIn('no_such_attribute', exception_args[0])
+
+
     def test_del_unknown_callable_attr_raises_attribute_error(self):
         """
         Deleting an unknown Callable attribute raises AttributeError.


### PR DESCRIPTION
Should address #85.