### PR TITLE
Docstring fix for the _wires module: repr now includes id.

### DIFF
--- a/src/wires/_wires.py
+++ b/src/wires/_wires.py
@@ -30,7 +30,7 @@ True
 1
 >>> for c in w:             # Iterating over all callables.
 ...     print(c)
-<WiresCallable 'one_callable'>
+<WiresCallable 'one_callable' at 0x1018d4a90>
 
 
 Deleting attributes deletes the associated callable:


### PR DESCRIPTION
Minor contribution to #16.