### PR TITLE
Update all PyPI links to the new pypi.org domain.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Python Wires: Simple Callable Wiring
 ====================================
 
 .. image:: http://img.shields.io/pypi/v/wires.svg
-   :target: https://pypi.python.org/pypi/wires
+   :target: https://pypi.org/pypi/wires
    :alt: PyPI
 
 .. image:: https://img.shields.io/travis/tmontes/python-wires.svg
@@ -27,7 +27,7 @@ Python Wires is a library to facilitate callable wiring by decoupling callers fr
 Installation
 ------------
 
-Python Wires is a pure Python package distributed via `PyPI <https://pypi.python.org/pypi/wires>`_. Install it with:
+Python Wires is a pure Python package distributed via `PyPI <https://pypi.org/pypi/wires>`_. Install it with:
 
 .. code-block:: console
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -46,7 +46,7 @@ Building the documentation, which will be available under ``docs/build/html/``:
     $ cd docs && make html
 
 
-Running the test suite with `tox <https://pypi.python.org/pypi/tox>`_:
+Running the test suite with `tox <https://pypi.org/pypi/tox>`_:
 
 .. code-block:: console
 
@@ -121,7 +121,7 @@ General requirements:
 
 * :guilabel:`bug` issues must:
 
-  * Be explicitly reported against either the latest `PyPI released version <https://pypi.python.org/pypi/wires>`_ or the current `GitHub master branch <https://github.com/tmontes/python-wires/tree/master>`_.
+  * Be explicitly reported against either the latest `PyPI released version <https://pypi.org/pypi/wires>`_ or the current `GitHub master branch <https://github.com/tmontes/python-wires/tree/master>`_.
 
   * Describe the steps to reproduce the bug, ideally with a minimal code sample.
 
@@ -197,7 +197,7 @@ Once confirmed, rename the :guilabel:`NEXT` milestone to :guilabel:`YY.MINOR.MIC
 
     .. code-block:: console
 
-        $ pip install -i https://testpypi.python.org/pypi wires
+        $ pip install -i https://test.pypi.org/pypi wires
 
   - If ok, upload to PyPI:
 

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -13,7 +13,7 @@ There is, however, a limited set of interpreters and platforms where development
 
 .. important::
 
-    For these motives, the only supported version is the latest `PyPI released version <https://pypi.python.org/pypi/wires>`_, running on an interpreter and platform for which automated testing is in place:
+    For these motives, the only supported version is the latest `PyPI released version <https://pypi.org/pypi/wires>`_, running on an interpreter and platform for which automated testing is in place:
 
     * CPython 2.7 on a glibc based Linux system.
     * CPython 3.6 on a glibc based Linux system.


### PR DESCRIPTION
Addresses #102.